### PR TITLE
Add RngCore trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /target
 **/*.rs.bk
 Cargo.lock
+
+fuzz/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcg"
-version = "0.2.0"
+version = "1.0.0"
 authors = ["Afnan Enayet <afnan.enayet@gmail.com>"]
 
 # Metadata for crates.io
@@ -9,6 +9,9 @@ description = "A port of the PCG random number generation library"
 repository = "https://github.com/afnanenayet/pcg-rs"
 readme = "docs/README.md"
 license = "MIT"
+
+[dependencies]
+rand_core = "0.2.1"
 
 # badges
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcg"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Afnan Enayet <afnan.enayet@gmail.com>"]
 
 # Metadata for crates.io
@@ -16,9 +16,3 @@ license = "MIT"
 
 travis-ci = { repository = "afnanenayet/pcg-rs", branch = "master" }
 maintenance = { status = "actively-developed" }
-
-[profile.release]
-opt-level = 3
-debug = false
-lto = false
-overflow-checks = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ license = "MIT"
 [dependencies]
 rand_core = "0.2.1"
 
+[dev-dependencies]
+rand = "0.5.5"
+
 # badges
 
 [badges]

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,11 @@
 This is a port of the PCG random number generation libary, made for C and C++,
 to Rust.
 
-The library provides a simple interface to generate random 32 bit unsigned integers.
+The library implements the `RngCore` trait, which automatically implements the
+`Rng` trait, providing a standard interface to generate and sample random numbers.
+
+_Note_: with the 1.0.0 release of pcg-rs, the old sampling methods have been deprecated,
+please use the sampling methods implemented via the `Rng` trait instead.
 
 http://www.pcg-random.org
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,0 +1,11 @@
+//! Contains arbitrary constants for use in the `pcg-rs` crate.
+
+/// The initial/default state to initialize the Pcg struct with
+pub const INIT_STATE: u64 = 0x853c_49e6_748f_ea9b;
+
+/// The initial/default incrementing value to initialize the Pcg struct with
+pub const INIT_INC: u64 = 0xda3e_39cb_94b9_5bdb;
+
+/// The value to multiply the state with when a random number is generated in order to
+/// alter the random number generator's state
+pub const INCREMENTOR: u64 = 6_364_136_223_846_793_005;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,25 @@
-/// The PCG crate is a port of the C/C++ PCG library for generating random
-/// numbers.
+//! # Synopsis
+//!
+//! The PCG crate is a port of the C/C++ PCG library for generating random
+//! numbers. It implements the `Rng` trait so all of the standard Rust methods
+//! for generating random numbers are available.
+//!
+//! _Note: you must use the `rand` crate if you want to use the methods provided
+//! by the `Rng` crate._
+//!
+//! # Basic Usage
+//!
+//! ```
+//! # extern crate rand;
+//! # extern crate pcg;
+//!
+//! use rand::Rng;
+//! use pcg::Pcg;
+//!
+//! let mut rng: Pcg = Default::default();  // remember to make this mutable
+//! let x: f64 = rng.gen();  // "canonical" random number in the range [0, 1)
+//! ```
+
 extern crate rand_core;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ impl Pcg {
             inc: (seq << 1) | 1,
         };
         rng.state += seed;
-        return rng;
+        rng
     }
 
     /// Generates a random unsigned 32 bit integer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 
 extern crate rand_core;
 
+#[cfg(test)]
+extern crate rand;
+
 use std::num::Wrapping;
 use rand_core::{RngCore, Error, impls};
 
@@ -84,6 +87,11 @@ impl Pcg {
     /// // create a random number in the range [0, 10)
     /// let bounded_random_number = rng.bounded_rand(10);
     /// ```
+    #[deprecated(
+        since = "1.0.0", note =
+        "Please use the `gen_range` or uniform distribution methods provided by the `Rng` trait
+        instead."
+    )]
     pub fn bounded_rand(&mut self, bound: u32) -> u32 {
         let threshold = (-(bound as i32) % (bound as i32)) as u32;
 
@@ -147,6 +155,17 @@ impl Default for Pcg {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::Rng;
+
+    #[test]
+    fn test_init() {
+        let _rng = Pcg::new(0, 0);
+    }
+
+    #[test]
+    fn test_init_default() {
+        let _rng: Pcg = Default::default();
+    }
 
     #[test]
     /// Checks that there are no runtime errors when generating random numbers
@@ -156,7 +175,7 @@ mod tests {
         let n = 100000000;
 
         for _ in 0..n {
-            let _rand = rng.rand();
+            let _rand = rng.next_u32();
         }
     }
 
@@ -167,7 +186,7 @@ mod tests {
         let mut v = vec![0 as u32; 10];
 
         for _ in 0..n {
-            let rand = rng.bounded_rand(10);
+            let rand = rng.gen_range(0, 10);
             assert!(rand < 10);
             v[rand as usize] += 1;
         }
@@ -175,7 +194,7 @@ mod tests {
 
         let mut v = vec![0 as u32; 2];
         for _ in 0..n {
-            let rand = rng.bounded_rand(2);
+            let rand = rng.gen_range(0, 2);
             assert!(rand < 2);
             v[rand as usize] += 1;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 //! ```
 //! # extern crate rand;
 //! # extern crate pcg;
-//!
 //! use rand::Rng;
 //! use pcg::Pcg;
 //!
@@ -25,6 +24,9 @@ extern crate rand_core;
 #[cfg(test)]
 extern crate rand;
 
+mod consts;
+
+use consts::{INCREMENTOR, INIT_INC, INIT_STATE};
 use rand_core::{impls, Error, RngCore};
 use std::num::Wrapping;
 
@@ -83,7 +85,7 @@ impl Pcg {
     )]
     pub fn rand(&mut self) -> u32 {
         let old_state = self.state;
-        self.state = (Wrapping(old_state) * Wrapping(6364136223846793005) + Wrapping(self.inc)).0;
+        self.state = (Wrapping(old_state) * Wrapping(INCREMENTOR) + Wrapping(self.inc)).0;
         let xor_shifted = (old_state >> 18) ^ old_state >> 27;
         // need to cast to i64 to allow the `-` operator (casting between integers of
         // the same size is a no-op)
@@ -134,8 +136,9 @@ impl RngCore for Pcg {
 
     fn next_u64(&mut self) -> u64 {
         let old_state = self.state;
-        self.state = (Wrapping(old_state) * Wrapping(6364136223846793005) + Wrapping(self.inc)).0;
+        self.state = (Wrapping(old_state) * Wrapping(INCREMENTOR) + Wrapping(self.inc)).0;
         let xor_shifted = (old_state >> 18) ^ old_state >> 27;
+
         // need to cast to i64 to allow the `-` operator (casting between integers of
         // the same size is a no-op)
         let rot = (old_state >> 59) as i64;
@@ -167,8 +170,8 @@ impl Default for Pcg {
     /// ```
     fn default() -> Pcg {
         Pcg {
-            state: 0x853c49e6748fea9b,
-            inc: 0xda3e39cb94b95bdb,
+            state: INIT_STATE,
+            inc: INIT_INC,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,12 @@
 /// The PCG crate is a port of the C/C++ PCG library for generating random
 /// numbers.
-
 extern crate rand_core;
 
 #[cfg(test)]
 extern crate rand;
 
+use rand_core::{impls, Error, RngCore};
 use std::num::Wrapping;
-use rand_core::{RngCore, Error, impls};
 
 /// The `Pcg` state struct contains state information for use by the random
 /// number generating functions.
@@ -59,7 +58,9 @@ impl Pcg {
     /// let mut rng = Pcg::default();
     /// let random_number = rng.rand();
     /// ```
-    #[deprecated(since="1.0.0", note="Please use the methods provided by the `Rng` trait instead.")]
+    #[deprecated(
+        since = "1.0.0", note = "Please use the methods provided by the `Rng` trait instead."
+    )]
     pub fn rand(&mut self) -> u32 {
         let old_state = self.state;
         self.state = (Wrapping(old_state) * Wrapping(6364136223846793005) + Wrapping(self.inc)).0;
@@ -88,8 +89,8 @@ impl Pcg {
     /// let bounded_random_number = rng.bounded_rand(10);
     /// ```
     #[deprecated(
-        since = "1.0.0", note =
-        "Please use the `gen_range` or uniform distribution methods provided by the `Rng` trait
+        since = "1.0.0",
+        note = "Please use the `gen_range` or uniform distribution methods provided by the `Rng` trait
         instead."
     )]
     pub fn bounded_rand(&mut self, bound: u32) -> u32 {


### PR DESCRIPTION
Add RngCore trait so the library can utilize the standard Rng trait and associated methods. Closes issue #1 